### PR TITLE
fix logic so isort and black run when you don't supply "only" args

### DIFF
--- a/pyfmt/__init__.py
+++ b/pyfmt/__init__.py
@@ -1,9 +1,8 @@
 import os
 import shlex
-from shutil import get_terminal_size
 import subprocess
 import sys
-import time
+from shutil import get_terminal_size
 from subprocess import PIPE
 
 TARGET_VERSION = f"py{sys.version_info.major}{sys.version_info.minor}"
@@ -26,6 +25,7 @@ BLACK_CMD = [
     "{extra_black_args}",
     "{path}",
 ]
+
 
 def find_all_files_and_dirs():
     """
@@ -53,20 +53,25 @@ def display_divider(title="", character="="):
     """
     if title:
         print(
-            "\n"
-            + "  {}  ".format(title.upper()).center(
+            "\n",
+            "  {}  ".format(title.upper()).center(
                 get_terminal_size().columns, "{}".format(character)
-            )
+            ),
         )
     else:
-        print(
-            "\n"
-            + "".center(get_terminal_size().columns, "{}".format(character))
-        )
+        print("\n" + "".center(get_terminal_size().columns, "{}".format(character)))
 
 
 def pyfmt(
-    path, skip="", isort_only=False, black_only=False, check=False, line_length=100, show_title=False, extra_isort_args="", extra_black_args=""
+    path,
+    skip="",
+    isort_only=False,
+    black_only=False,
+    check=False,
+    line_length=100,
+    show_title=False,
+    extra_isort_args="",
+    extra_black_args="",
 ) -> int:
     """Run isort and black with the given params and print the results."""
     if skip:
@@ -88,7 +93,9 @@ def pyfmt(
                             files_in_dir.append(filename)
                 filenames_to_skip.extend(files_in_dir)
             else:
-                print(f'CRITICAL: One of the files or directories marked as skipped not found ("{item}").')
+                print(
+                    f'CRITICAL: One of the files or directories marked as skipped not found ("{item}").'
+                )
                 print("CRITICAL: Check spelling or existence of file or directory")
                 print("CRITICAL: Aborting pyfmt ...")
                 sys.exit()
@@ -111,14 +118,14 @@ def pyfmt(
 
     # Executing isort import formatter
     isort_exitcode = 0
-    if isort_only:
+    if not black_only:
         isort_exitcode = run_formatter(
             ISORT_CMD, path, line_length=line_length, extra_isort_args=extra_isort_args
         )
 
     # Executing black code formatter
     black_exitcode = 0
-    if black_only:
+    if not isort_only:
         black_exitcode = run_formatter(
             BLACK_CMD, path, line_length=line_length, extra_black_args=extra_black_args
         )

--- a/pyfmt/__main__.py
+++ b/pyfmt/__main__.py
@@ -21,8 +21,12 @@ def main():
     parser.add_argument(
         "--skip", default="", help="Directory (ie. env/foo) or files (ie. cool.py) to skip."
     )
-    parser.add_argument("--isort-only", action="store_true", help="Only process with isort (imports only)")
-    parser.add_argument("--black-only", action="store_true", help="Only process with black (code only)")
+    parser.add_argument(
+        "--isort-only", action="store_true", help="Only process with isort (imports only)"
+    )
+    parser.add_argument(
+        "--black-only", action="store_true", help="Only process with black (code only)"
+    )
     parser.add_argument(
         "--check",
         action="store_true",


### PR DESCRIPTION
it looks like `pyfmt` still needed to be ran against the PR and, since i ran it, this ended up changing some formatting...hence all the little changes. I've noted the actual logic change.